### PR TITLE
Split expose ports based on Dockerfile reference.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -89,7 +89,7 @@ RUN FEXInterpreter /home/steam/Steam/steamcmd.sh \
     +quit && \
     rm -rf /home/steam/Steam/logs /home/steam/Steam/appcache
 
-EXPOSE 16261-16262/udp 27015/tcp
+EXPOSE 16261/udp 16262/udp 27015/tcp
 
 WORKDIR /home/steam/Zomboid
 


### PR DESCRIPTION
`EXPOSE` syntax doesn't accept number-number port format. Fix the issues that make it fail to pull the image.

See docs: https://docs.docker.com/reference/dockerfile/#expose


```
$ docker pull etheth888/project-zomboid-arm64:main
main: Pulling from etheth888/project-zomboid-arm64
0ec3d8645767: Pulling fs layer
39635e686df7: Pulling fs layer
2e04fbb42033: Downloading [>                                                  ]  41.05kB/4.034MB
ba49aa4851f7: Waiting
22d4dc3a4e52: Waiting
910503697a95: Waiting
8b8062131524: Waiting
invalid port '16261-16262': invalid syntax
```